### PR TITLE
Feat/comment model: コメント機能を実装しました

### DIFF
--- a/.annotaterb.yml
+++ b/.annotaterb.yml
@@ -1,0 +1,58 @@
+---
+:position: before
+:position_in_additional_file_patterns: before
+:position_in_class: before
+:position_in_factory: before
+:position_in_fixture: before
+:position_in_routes: before
+:position_in_serializer: before
+:position_in_test: before
+:classified_sort: true
+:exclude_controllers: true
+:exclude_factories: false
+:exclude_fixtures: false
+:exclude_helpers: true
+:exclude_scaffolds: true
+:exclude_serializers: false
+:exclude_sti_subclasses: false
+:exclude_tests: false
+:force: false
+:format_markdown: false
+:format_rdoc: false
+:format_yard: false
+:frozen: false
+:ignore_model_sub_dir: false
+:ignore_unknown_models: false
+:include_version: false
+:show_check_constraints: false
+:show_complete_foreign_keys: false
+:show_foreign_keys: true
+:show_indexes: true
+:simple_indexes: false
+:sort: false
+:timestamp: false
+:trace: false
+:with_comment: true
+:with_column_comments: true
+:with_table_comments: true
+:active_admin: false
+:command:
+:debug: false
+:hide_default_column_types: ''
+:hide_limit_column_types: ''
+:ignore_columns:
+:ignore_routes:
+:models: true
+:routes: false
+:skip_on_db_migrate: false
+:target_action: :do_annotations
+:wrapper:
+:wrapper_close:
+:wrapper_open:
+:classes_default_to_s: []
+:additional_file_patterns: []
+:model_dir:
+- app/models
+:require: []
+:root_dir:
+- ''

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,7 @@
 @use "./tabs.scss";
 @use "./article.scss";
 @use "./common.scss";
+@use "./comment.scss";
 
 
 html {

--- a/app/assets/stylesheets/card.scss
+++ b/app/assets/stylesheets/card.scss
@@ -29,6 +29,19 @@ $avatar-size: 32px;
       line-height: $heart-size;
     }
   }
+
+  &_comments {
+    display: flex;
+    p {
+      font-size: 12px;
+    }
+    span {
+      margin-left: 8px;
+      font-size: 12px;
+      color: variables.$primary-color;
+    }
+  }
+
   &_detail {
     padding-top: 12px;
     cursor: pointer;

--- a/app/assets/stylesheets/comment.scss
+++ b/app/assets/stylesheets/comment.scss
@@ -1,0 +1,14 @@
+
+.comment {
+  background-color: white;
+  margin: 16px 16px;
+  padding: 16px 16px;
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.25);
+  position: relative;
+
+  &_detail {
+    margin-bottom: 10px;
+    display: flex;
+    gap: 40px
+  }
+}

--- a/app/assets/stylesheets/comment.scss
+++ b/app/assets/stylesheets/comment.scss
@@ -17,10 +17,17 @@
     display: flex;
     flex-wrap: nowrap; /* 不要な折り返しを防ぐ */
     align-items: center; /* 垂直方向の配置を統一 */
+    justify-content: flex-start;
     gap: 16px; /* 適切な間隔を設定 */
-    & > * {
-      min-width: 50px; /* 各要素が狭くなりすぎないようにする */
-      flex-grow: 1; /* 要素が均等にスペースを取るようにする */
+
+    &_name {
+      flex: 1 1 10%
+    }
+    &_content {
+      flex: 7 5 70%
+    }
+    &_delete {
+      flex: 2 2 20%
     }
   }
 }

--- a/app/assets/stylesheets/comment.scss
+++ b/app/assets/stylesheets/comment.scss
@@ -1,14 +1,27 @@
-
 .comment {
   background-color: white;
-  margin: 16px 16px;
-  padding: 16px 16px;
+  margin: 16px;
+  padding: 16px;
   box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.25);
   position: relative;
+  max-width: 100%;
+  word-break: break-word; /* 長い単語の折り返し */
+  overflow-wrap: break-word;
+
+  h2 {
+    font-size: 18px;
+  }
 
   &_detail {
     margin-bottom: 10px;
     display: flex;
-    gap: 40px
+    flex-wrap: nowrap; /* 不要な折り返しを防ぐ */
+    align-items: center; /* 垂直方向の配置を統一 */
+    gap: 16px; /* 適切な間隔を設定 */
+    & > * {
+      min-width: 50px; /* 各要素が狭くなりすぎないようにする */
+      flex-grow: 1; /* 要素が均等にスペースを取るようにする */
+    }
   }
 }
+

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -8,6 +8,7 @@ class ArticlesController < ApplicationController
   end
 
   def show
+    @comments = @article.comments.all
   end
 
   def new

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,4 @@
+class CommentsController < ApplicationController
+  before_action :authenticate_user!
+
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -8,8 +8,7 @@ class CommentsController < ApplicationController
   end
 
   def create
-    # TODO: 長いのでメソッドとして切りだす
-    @comment = current_user.comments.build(comment_params.merge(article_id: params[:article_id]))
+    @comment = current_user.comments.build(merged_params)
     if @comment.save
       flash[:notice] = "コメントしました"
       redirect_to article_path(@comment.article)
@@ -30,6 +29,10 @@ class CommentsController < ApplicationController
 
   def comment_params
     params.require(:comment).permit(:content)
+  end
+
+  def merged_params
+    comment_params.merge(article_id: params[:article_id])
   end
 
   def set_comment

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -6,6 +6,7 @@ class CommentsController < ApplicationController
   end
 
   def create
+    # TODO: 長いのでメソッドとして切りだす
     @comment = current_user.comments.build(comment_params.merge(article_id: params[:article_id]))
     if @comment.save
       flash[:notice] = "コメントしました"

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,4 +4,23 @@ class CommentsController < ApplicationController
   def new
     @comment = current_user.comments.build(article_id: params[:article_id])
   end
+
+  def create
+    @comment = current_user.comments.build(comment_params.merge(article_id: params[:article_id]))
+    if @comment.save
+      flash[:notice] = "コメントしました"
+      redirect_to article_path(@comment.article)
+    else
+      flash.now[:error] = "コメントに失敗しました"
+      render :new, status: :unprocessable_entity
+    end
+
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:content)
+  end
+
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -16,7 +16,6 @@ class CommentsController < ApplicationController
       flash.now[:error] = "コメントに失敗しました"
       render :new, status: :unprocessable_entity
     end
-
   end
 
   def destroy
@@ -45,5 +44,4 @@ class CommentsController < ApplicationController
       redirect_to article_path(@comment.article)
     end
   end
-
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,7 @@
 class CommentsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_comment, only: [ :destroy ]
+  before_action :authorize_destroy, only: [ :destroy ]
 
   def new
     @comment = current_user.comments.build(article_id: params[:article_id])
@@ -18,10 +20,27 @@ class CommentsController < ApplicationController
 
   end
 
+  def destroy
+    @comment.destroy!
+    flash[:notice] = "コメントを削除しました"
+    redirect_to article_path(@comment.article), status: :see_other
+  end
+
   private
 
   def comment_params
     params.require(:comment).permit(:content)
+  end
+
+  def set_comment
+    @comment = Comment.find(params[:id])
+  end
+
+  def authorize_destroy
+    unless current_user == @comment.user || current_user == @comment.article.user
+      flash[:error] = "削除権限がありません"
+      redirect_to article_path(@comment.article)
+    end
   end
 
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,7 @@
 class CommentsController < ApplicationController
   before_action :authenticate_user!
 
+  def new
+    @comment = current_user.comments.build(article_id: params[:article_id])
+  end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -8,7 +8,7 @@ class CommentsController < ApplicationController
   end
 
   def create
-    @comment = current_user.comments.build(merged_params)
+    @comment = current_user.comments.build(comment_creation_params)
     if @comment.save
       flash[:notice] = "コメントしました"
       redirect_to article_path(@comment.article)
@@ -31,7 +31,7 @@ class CommentsController < ApplicationController
     params.require(:comment).permit(:content)
   end
 
-  def merged_params
+  def comment_creation_params
     comment_params.merge(article_id: params[:article_id])
   end
 

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -6,7 +6,7 @@ module ArticlesHelper
   def display_eye_catch(article)
     return unless article.eye_catch.attached?
 
-    content_tag(:div, class: 'article_image') do
+    content_tag(:div, class: "article_image") do
       image_tag(article.eye_catch)
     end
   end
@@ -14,12 +14,12 @@ module ArticlesHelper
   def display_article_actions(article)
     return unless written_by_current_user?(article)
 
-    content_tag(:div, class: 'article_detail_actions') do
-      content_tag(:div, class: 'dropdown') do
-        image_tag('actions.svg', class: "dropbtn").html_safe +
-        content_tag(:div, class: 'dropdown-content mini') do
-          link_to('編集する', edit_article_path(article)).html_safe +
-          link_to('削除する', article_path(article), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' })
+    content_tag(:div, class: "article_detail_actions") do
+      content_tag(:div, class: "dropdown") do
+        image_tag("actions.svg", class: "dropbtn").html_safe +
+        content_tag(:div, class: "dropdown-content mini") do
+          link_to("編集する", edit_article_path(article)).html_safe +
+          link_to("削除する", article_path(article), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" })
         end
       end
     end

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -2,4 +2,26 @@ module ArticlesHelper
   def formatted_created_at(article)
     l article.created_at, format: :short
   end
+
+  def display_eye_catch(article)
+    return unless article.eye_catch.attached?
+
+    content_tag(:div, class: 'article_image') do
+      image_tag(article.eye_catch)
+    end
+  end
+
+  def display_article_actions(article)
+    return unless written_by_current_user?(article)
+
+    content_tag(:div, class: 'article_detail_actions') do
+      content_tag(:div, class: 'dropdown') do
+        image_tag('actions.svg', class: "dropbtn").html_safe +
+        content_tag(:div, class: 'dropdown-content mini') do
+          link_to('編集する', edit_article_path(article)).html_safe +
+          link_to('削除する', article_path(article), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' })
+        end
+      end
+    end
+  end
 end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,5 @@
+module CommentsHelper
+  def has_delete_authority?(comment, article)
+    current_user == comment.user || current_user == article.user
+  end
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: articles
+#
+#  id         :bigint           not null, primary key
+#  content    :text             not null
+#  title      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_articles_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 class Article < ApplicationRecord
   validates :title, presence: true
   validates :content, presence: true

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,6 +4,7 @@ class Article < ApplicationRecord
   validates :content, uniqueness: true
 
   belongs_to :user
+  has_many :comments, dependent: :destroy
   has_one_attached :eye_catch
 
   def formats_created_at

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,4 @@
+class Comment < ApplicationRecord
+  belongs_to :article
+  belongs_to :user
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -20,6 +20,8 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Comment < ApplicationRecord
+  validates :content, presence: true
+
   belongs_to :article
   belongs_to :user
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :bigint           not null, primary key
+#  content    :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  article_id :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_comments_on_article_id  (article_id)
+#  index_comments_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (article_id => articles.id)
+#  fk_rails_...  (user_id => users.id)
+#
 class Comment < ApplicationRecord
   belongs_to :article
   belongs_to :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :articles, dependent: :destroy
+  has_many :comments, dependent: :destroy
 
   def display_name
     self.email.split("@").first

--- a/app/views/articles/_display_comments.html.haml
+++ b/app/views/articles/_display_comments.html.haml
@@ -1,0 +1,5 @@
+.comment_detail
+  %p.comment_detail_name= comment.user.display_name
+  %p.comment_detail_content= comment.content
+  - if has_delete_authority?(comment, article)
+    = link_to '削除', article_comment_path(article, comment), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'comment_detail_delete'

--- a/app/views/articles/index.html.haml
+++ b/app/views/articles/index.html.haml
@@ -17,6 +17,9 @@
           .card_heart
             = image_tag 'heart.svg'
             %span 23
+          .card_comments
+            %p comments
+            %span= article.comments.count
           .card_detail
             = image_tag 'default-avatar.png'
             %div

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -1,33 +1,20 @@
 .article
-  - if @article.eye_catch.attached?
-    .article_image
-      = image_tag @article.eye_catch
+  = display_eye_catch(@article)
   %h1.article_title= @article.title
   .article_detail
     %div
       %p= @article.user.display_name
       %p= formatted_created_at(@article)
-    - if written_by_current_user?(@article)
-      .article_detail_actions
-        .dropdown
-          = image_tag 'actions.svg', class: "dropbtn"
-          .dropdown-content.mini
-            = link_to '編集する', edit_article_path(@article)
-            = link_to '削除する', article_path(@article), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }
+    = display_article_actions(@article)
   .article_content
     = @article.content
   .article_heart
     = image_tag 'heart.svg'
 - if @comments.present?
   .comment
-    -# TODO: Helperメソッドなどでリファクタリング
     %h2 コメント
     - @comments.each do |comment|
-      .comment_detail
-        %p.comment_detail_name= comment.user.display_name
-        %p.comment_detail_content= comment.content
-        - if current_user == comment.user || current_user == @article.user
-          = link_to '削除', article_comment_path(@article, comment), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'comment_detail_delete'
+      = render 'display_comments', comment: comment, article: @article
 
 .container
   = link_to new_article_comment_path(@article) do

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -18,3 +18,15 @@
     = @article.content
   .article_heart
     = image_tag 'heart.svg'
+
+.comment
+  -# TODO: Helperメソッドなどでリファクタリング
+  - @comments.each do |comment|
+    .comment_detail
+      %p= comment.user.display_name
+      %p= comment.content
+
+.container
+  = link_to new_article_comment_path(@article) do
+    .btn-secondly
+      コメントする

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -24,10 +24,10 @@
     %h2 コメント
     - @comments.each do |comment|
       .comment_detail
-        %p= comment.user.display_name
-        %p= comment.content
+        %p.comment_detail_name= comment.user.display_name
+        %p.comment_detail_content= comment.content
         - if current_user == comment.user || current_user == @article.user
-          = link_to '削除', article_comment_path(@article, comment), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }
+          = link_to '削除', article_comment_path(@article, comment), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'comment_detail_delete'
 
 .container
   = link_to new_article_comment_path(@article) do

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -18,13 +18,16 @@
     = @article.content
   .article_heart
     = image_tag 'heart.svg'
-
-.comment
-  -# TODO: Helperメソッドなどでリファクタリング
-  - @comments.each do |comment|
-    .comment_detail
-      %p= comment.user.display_name
-      %p= comment.content
+- if @comments.present?
+  .comment
+    -# TODO: Helperメソッドなどでリファクタリング
+    %h2 コメント
+    - @comments.each do |comment|
+      .comment_detail
+        %p= comment.user.display_name
+        %p= comment.content
+        - if current_user == comment.user || current_user == @article.user
+          = link_to '削除', article_comment_path(@article, comment), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }
 
 .container
   = link_to new_article_comment_path(@article) do

--- a/app/views/comments/new.html.haml
+++ b/app/views/comments/new.html.haml
@@ -1,0 +1,10 @@
+.container
+  %h1 コメントする
+  = render 'common/error_messages', object: @comment
+
+  = form_with model: @comment, url: article_comments_path(@comment.article), method: :post, local: true do |f|
+    %div
+      =f.label :content, "コメント"
+      =f.text_area :content
+    %div
+      =f.submit "投稿する", class: 'btn-primary'

--- a/app/views/comments/new.html.haml
+++ b/app/views/comments/new.html.haml
@@ -1,5 +1,5 @@
 .container
-  %h1 コメントする
+  %h1 コメント投稿
   = render 'common/error_messages', object: @comment
 
   = form_with model: @comment, url: article_comments_path(@comment.article), method: :post, local: true do |f|

--- a/config/locales/model/ja.yml
+++ b/config/locales/model/ja.yml
@@ -2,7 +2,11 @@ ja:
   activerecord:
     models:
       article: 記事
+      comment: コメント
     attributes:
       article:
         title: タイトル
         content: 本文
+      comment:
+        content: コメント
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,7 @@ Rails.application.routes.draw do
   }
   get "up" => "rails/health#show", as: :rails_health_check
   root to: "articles#index"
-  resources :articles
+  resources :articles do
+    resources :comments, only: [ :new, :create, :destroy ]
+  end
 end

--- a/db/migrate/20250218145448_create_comments.rb
+++ b/db/migrate/20250218145448_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[8.0]
+  def change
+    create_table :comments do |t|
+      t.references :article, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.text :content, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_17_123105) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_18_145448) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -51,6 +51,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_123105) do
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
+  create_table "comments", force: :cascade do |t|
+    t.bigint "article_id", null: false
+    t.bigint "user_id", null: false
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["article_id"], name: "index_comments_on_article_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -66,4 +76,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_123105) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "articles", "users"
+  add_foreign_key "comments", "articles"
+  add_foreign_key "comments", "users"
 end

--- a/lib/tasks/annotate_rb.rake
+++ b/lib/tasks/annotate_rb.rake
@@ -1,0 +1,8 @@
+# This rake task was added by annotate_rb gem.
+
+# Can set `ANNOTATERB_SKIP_ON_DB_TASKS` to be anything to skip this
+if Rails.env.development? && ENV["ANNOTATERB_SKIP_ON_DB_TASKS"].nil?
+  require "annotate_rb"
+
+  AnnotateRb::Core.load_rake_tasks
+end

--- a/test/fixtures/articles.yml
+++ b/test/fixtures/articles.yml
@@ -4,6 +4,25 @@
 # model remove the "{}" from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
+# == Schema Information
+#
+# Table name: articles
+#
+#  id         :bigint           not null, primary key
+#  content    :text             not null
+#  title      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_articles_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 one: {}
 # column: value
 #

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -4,6 +4,27 @@
 # model remove the "{}" from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :bigint           not null, primary key
+#  content    :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  article_id :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_comments_on_article_id  (article_id)
+#  index_comments_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (article_id => articles.id)
+#  fk_rails_...  (user_id => users.id)
+#
 one: {}
 # column: value
 #

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,6 +4,24 @@
 # model remove the "{}" from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 one: {}
 # column: value
 #

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: articles
+#
+#  id         :bigint           not null, primary key
+#  content    :text             not null
+#  title      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_articles_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 require "test_helper"
 
 class ArticleTest < ActiveSupport::TestCase

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :bigint           not null, primary key
+#  content    :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  article_id :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_comments_on_article_id  (article_id)
+#  index_comments_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (article_id => articles.id)
+#  fk_rails_...  (user_id => users.id)
+#
 require "test_helper"
 
 class CommentTest < ActiveSupport::TestCase

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase


### PR DESCRIPTION
## 変更の概要
- Model
  - Userと1対N関係（Commentモデルが従属）
  - Articleと1対N関係（Commentモデルが従属）
  - 上記以外は本文とデフォルトのみ
- Controller（アクション）
  - new
  - create
  - destroy
    - 権限はコメントしたユーザーと記事を作成したユーザー
- View
  - 新規
    - コメント投稿フォーム
  - 既存
    - 記事詳細画面にコメント投稿フォームへのリンクとコメント一覧を追加

### 関連するIssue
close #9 

## なぜこの変更をするのか
- ユーザー間のコミュニケーションを活性化するため

## 変更内容
### 投稿フォーム
![image](https://github.com/user-attachments/assets/3b5b9a33-19d3-4337-9271-2751c34276ab)

### コメント一覧
![image](https://github.com/user-attachments/assets/795ed6ed-c6a1-45ae-b5c0-ba120da783ef)

## 影響範囲
- システムに影響すること
  - 既存の記事詳細画面とarticleモデルのshowアクションを修正

## テスト内容（手動）
1. 要件
    1. 正常系
        1. コメントが作成できる
        2. コメントが表示される
        3. 一覧画面にコメント数が反映される
        4. 記事の作者の場合、他のユーザーのコメントを削除できる
        5. コメントした場合、他のユーザーのコメントを削除できる
    2. 異常系
        1. バリデーションエラーが表示される
        2. 記事の作者でもコメントしてもいない場合、コメントを削除できない
2. デグレ
    1. 修正箇所のcssがあたっているページ
    2. article/showの画面確認
    3. articles/index
2.
